### PR TITLE
Update cmake min version to match rest of mysql package

### DIFF
--- a/cdk/extra/lz4/CMakeLists.txt
+++ b/cdk/extra/lz4/CMakeLists.txt
@@ -26,7 +26,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8)
 PROJECT(zstd C)
 
 include(../setup.cmake)

--- a/cdk/extra/protobuf/CMakeLists.txt
+++ b/cdk/extra/protobuf/CMakeLists.txt
@@ -57,7 +57,7 @@
 # - fix minor compilation issues on SunPro 5.14.0
 
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 PROJECT(Protobuf)
 
 include(../setup.cmake)

--- a/cdk/extra/zlib/CMakeLists.txt
+++ b/cdk/extra/zlib/CMakeLists.txt
@@ -21,7 +21,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-cmake_minimum_required(VERSION 2.4.4)
+cmake_minimum_required(VERSION 3.8)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
 
 set(VERSION "1.2.13")

--- a/cdk/extra/zstd/CMakeLists.txt
+++ b/cdk/extra/zstd/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ################################################################
 
 PROJECT(zstd)
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.8)
 
 include(../setup.cmake)
 include(platform)


### PR DESCRIPTION
We need a cmake minimum >= 3.5 to work with cmake 4.* and we updated cmake to a version that knew about VS2026

Rest of mysql package specifies a minimum  of 3.8 so update these to match